### PR TITLE
Fix: Account for decimals when displaying underlying token balance

### DIFF
--- a/.changeset/seven-cherries-think.md
+++ b/.changeset/seven-cherries-think.md
@@ -1,0 +1,5 @@
+---
+"@superfluid-finance/widget": patch
+---
+
+Fix underlying token balance not accounting for decimals when displaying it

--- a/apps/hosted-widget/package.json
+++ b/apps/hosted-widget/package.json
@@ -18,7 +18,7 @@
     "@mui/material": "^5.14.0",
     "@segment/analytics-next": "^1.53.0",
     "@sentry/nextjs": "^7.58.1",
-    "@superfluid-finance/tokenlist": "^1.3.1",
+    "@superfluid-finance/tokenlist": "^1.3.2",
     "@superfluid-finance/widget": "workspace:*",
     "@web3modal/ethereum": "^2.7.0",
     "@web3modal/react": "^2.7.0",

--- a/apps/hosted-widget/package.json
+++ b/apps/hosted-widget/package.json
@@ -18,7 +18,7 @@
     "@mui/material": "^5.14.0",
     "@segment/analytics-next": "^1.53.0",
     "@sentry/nextjs": "^7.58.1",
-    "@superfluid-finance/tokenlist": "^1.3.0",
+    "@superfluid-finance/tokenlist": "^1.3.1",
     "@superfluid-finance/widget": "workspace:*",
     "@web3modal/ethereum": "^2.7.0",
     "@web3modal/react": "^2.7.0",

--- a/apps/widget-builder/package.json
+++ b/apps/widget-builder/package.json
@@ -22,7 +22,7 @@
     "@pinata/sdk": "^2.1.0",
     "@segment/analytics-next": "^1.53.0",
     "@sentry/nextjs": "^7.58.1",
-    "@superfluid-finance/tokenlist": "^1.3.1",
+    "@superfluid-finance/tokenlist": "^1.3.2",
     "@superfluid-finance/widget": "workspace:*",
     "@web3modal/ethereum": "^2.7.0",
     "@web3modal/react": "^2.7.0",

--- a/apps/widget-builder/package.json
+++ b/apps/widget-builder/package.json
@@ -22,7 +22,7 @@
     "@pinata/sdk": "^2.1.0",
     "@segment/analytics-next": "^1.53.0",
     "@sentry/nextjs": "^7.58.1",
-    "@superfluid-finance/tokenlist": "^1.3.0",
+    "@superfluid-finance/tokenlist": "^1.3.1",
     "@superfluid-finance/widget": "workspace:*",
     "@web3modal/ethereum": "^2.7.0",
     "@web3modal/react": "^2.7.0",

--- a/examples/b2b-service-demo/package.json
+++ b/examples/b2b-service-demo/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@sentry/nextjs": "^7.59.2",
-    "@superfluid-finance/tokenlist": "^1.3.0",
+    "@superfluid-finance/tokenlist": "^1.3.1",
     "@superfluid-finance/widget": "workspace:*",
     "@types/node": "20.4.2",
     "@types/react": "18.2.15",

--- a/examples/b2b-service-demo/package.json
+++ b/examples/b2b-service-demo/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@sentry/nextjs": "^7.59.2",
-    "@superfluid-finance/tokenlist": "^1.3.1",
+    "@superfluid-finance/tokenlist": "^1.3.2",
     "@superfluid-finance/widget": "workspace:*",
     "@types/node": "20.4.2",
     "@types/react": "18.2.15",

--- a/examples/donation-demo/package.json
+++ b/examples/donation-demo/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@sentry/nextjs": "^7.59.2",
-    "@superfluid-finance/tokenlist": "^1.3.0",
+    "@superfluid-finance/tokenlist": "^1.3.1",
     "@superfluid-finance/widget": "workspace:*",
     "@types/node": "20.4.2",
     "@types/react": "18.2.15",

--- a/examples/donation-demo/package.json
+++ b/examples/donation-demo/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@sentry/nextjs": "^7.59.2",
-    "@superfluid-finance/tokenlist": "^1.3.1",
+    "@superfluid-finance/tokenlist": "^1.3.2",
     "@superfluid-finance/widget": "workspace:*",
     "@types/node": "20.4.2",
     "@types/react": "18.2.15",

--- a/examples/widget-vite-react-rainbowkit/package.json
+++ b/examples/widget-vite-react-rainbowkit/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@rainbow-me/rainbowkit": "^1.0.6",
-    "@superfluid-finance/tokenlist": "^1.3.0",
+    "@superfluid-finance/tokenlist": "^1.3.1",
     "@superfluid-finance/widget": "workspace:*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/examples/widget-vite-react-rainbowkit/package.json
+++ b/examples/widget-vite-react-rainbowkit/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@rainbow-me/rainbowkit": "^1.0.6",
-    "@superfluid-finance/tokenlist": "^1.3.1",
+    "@superfluid-finance/tokenlist": "^1.3.2",
     "@superfluid-finance/widget": "workspace:*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/examples/widget-vite-react-web3modal/package.json
+++ b/examples/widget-vite-react-web3modal/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@superfluid-finance/tokenlist": "^1.3.0",
+    "@superfluid-finance/tokenlist": "^1.3.1",
     "@superfluid-finance/widget": "workspace:*",
     "@web3modal/ethereum": "^2.7.0",
     "@web3modal/react": "^2.7.0",

--- a/examples/widget-vite-react-web3modal/package.json
+++ b/examples/widget-vite-react-web3modal/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@superfluid-finance/tokenlist": "^1.3.1",
+    "@superfluid-finance/tokenlist": "^1.3.2",
     "@superfluid-finance/widget": "workspace:*",
     "@web3modal/ethereum": "^2.7.0",
     "@web3modal/react": "^2.7.0",

--- a/examples/widget-webcomponent/package.json
+++ b/examples/widget-webcomponent/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@superfluid-finance/tokenlist": "^1.3.1",
+    "@superfluid-finance/tokenlist": "^1.3.2",
     "@superfluid-finance/widget": "workspace:*"
   },
   "devDependencies": {

--- a/examples/widget-webcomponent/package.json
+++ b/examples/widget-webcomponent/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@superfluid-finance/tokenlist": "^1.3.0",
+    "@superfluid-finance/tokenlist": "^1.3.1",
     "@superfluid-finance/widget": "workspace:*"
   },
   "devDependencies": {

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -41,7 +41,7 @@
     "@mui/lab": "5.0.0-alpha.136",
     "@mui/utils": "^5.13.6",
     "@superfluid-finance/metadata": "^1.1.8",
-    "@superfluid-finance/tokenlist": "^1.2.0",
+    "@superfluid-finance/tokenlist": "^1.3.1",
     "blockies-ts": "^1.0.0",
     "immer": "^10.0.2",
     "lodash.isequal": "^4.1.2",

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -41,7 +41,7 @@
     "@mui/lab": "5.0.0-alpha.136",
     "@mui/utils": "^5.13.6",
     "@superfluid-finance/metadata": "^1.1.8",
-    "@superfluid-finance/tokenlist": "^1.3.1",
+    "@superfluid-finance/tokenlist": "^1.3.2",
     "blockies-ts": "^1.0.0",
     "immer": "^10.0.2",
     "lodash.isequal": "^4.1.2",

--- a/packages/widget/src/StepContentWrap.tsx
+++ b/packages/widget/src/StepContentWrap.tsx
@@ -122,7 +122,7 @@ export default function StepContentWrap() {
           token: underlyingToken.address as Address,
           address: accountAddress,
           chainId: paymentOptionWithTokenInfo.paymentOption.chainId,
-          formatUnits: "ether",
+          formatUnits: underlyingToken.decimals,
         }
       : undefined,
   );
@@ -133,7 +133,7 @@ export default function StepContentWrap() {
           token: superToken.address as Address,
           address: accountAddress,
           chainId: paymentOptionWithTokenInfo.paymentOption.chainId,
-          formatUnits: "ether",
+          formatUnits: "ether", // Super Tokens are always 18 decimals.
         }
       : undefined,
   );

--- a/packages/widget/src/previews/WrapIntoSuperTokensPreview.tsx
+++ b/packages/widget/src/previews/WrapIntoSuperTokensPreview.tsx
@@ -1,6 +1,6 @@
 import { Box, Paper, Stack, Typography } from "@mui/material";
 import { useMemo } from "react";
-import { formatEther } from "viem";
+import { formatUnits } from "viem";
 
 import { WrapIntoSuperTokensCommand } from "../commands.js";
 import { TokenAvatar } from "../TokenAvatar.js";
@@ -20,7 +20,7 @@ export function WrapIntoSuperTokensPreview({
     : getUnderlyingToken(cmd.underlyingToken.address);
 
   const amountEther = useMemo(
-    () => formatEther(cmd.amountWei),
+    () => formatUnits(cmd.amountWei, underlyingToken.decimals),
     [cmd.amountWei],
   );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: false
@@ -75,8 +75,8 @@ importers:
         specifier: ^7.58.1
         version: 7.58.1(next@13.4.9)(react@18.2.0)
       '@superfluid-finance/tokenlist':
-        specifier: ^1.3.0
-        version: 1.3.0
+        specifier: ^1.3.1
+        version: 1.3.1
       '@superfluid-finance/widget':
         specifier: workspace:*
         version: link:../../packages/widget
@@ -169,8 +169,8 @@ importers:
         specifier: ^7.58.1
         version: 7.58.1(next@13.4.9)(react@18.2.0)
       '@superfluid-finance/tokenlist':
-        specifier: ^1.3.0
-        version: 1.3.0
+        specifier: ^1.3.1
+        version: 1.3.1
       '@superfluid-finance/widget':
         specifier: workspace:*
         version: link:../../packages/widget
@@ -239,8 +239,8 @@ importers:
         specifier: ^7.59.2
         version: 7.59.2(next@13.4.9)(react@18.2.0)
       '@superfluid-finance/tokenlist':
-        specifier: ^1.3.0
-        version: 1.3.0
+        specifier: ^1.3.1
+        version: 1.3.1
       '@superfluid-finance/widget':
         specifier: workspace:*
         version: link:../../packages/widget
@@ -290,8 +290,8 @@ importers:
         specifier: ^7.59.2
         version: 7.59.2(next@13.4.9)(react@18.2.0)
       '@superfluid-finance/tokenlist':
-        specifier: ^1.3.0
-        version: 1.3.0
+        specifier: ^1.3.1
+        version: 1.3.1
       '@superfluid-finance/widget':
         specifier: workspace:*
         version: link:../../packages/widget
@@ -341,8 +341,8 @@ importers:
         specifier: ^1.0.6
         version: 1.0.6(@types/react@18.2.15)(react-dom@18.2.0)(react@18.2.0)(viem@1.2.15)(wagmi@1.3.8)
       '@superfluid-finance/tokenlist':
-        specifier: ^1.3.0
-        version: 1.3.0
+        specifier: ^1.3.1
+        version: 1.3.1
       '@superfluid-finance/widget':
         specifier: workspace:*
         version: link:../../packages/widget
@@ -396,8 +396,8 @@ importers:
   examples/widget-vite-react-web3modal:
     dependencies:
       '@superfluid-finance/tokenlist':
-        specifier: ^1.3.0
-        version: 1.3.0
+        specifier: ^1.3.1
+        version: 1.3.1
       '@superfluid-finance/widget':
         specifier: workspace:*
         version: link:../../packages/widget
@@ -457,8 +457,8 @@ importers:
   examples/widget-webcomponent:
     dependencies:
       '@superfluid-finance/tokenlist':
-        specifier: ^1.3.0
-        version: 1.3.0
+        specifier: ^1.3.1
+        version: 1.3.1
       '@superfluid-finance/widget':
         specifier: workspace:*
         version: link:../../packages/widget
@@ -511,8 +511,8 @@ importers:
         specifier: ^1.1.8
         version: 1.1.8
       '@superfluid-finance/tokenlist':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.3.1
+        version: 1.3.1
       blockies-ts:
         specifier: ^1.0.0
         version: 1.0.0
@@ -652,7 +652,7 @@ packages:
       '@babel/traverse': 7.22.8
       '@babel/types': 7.22.5
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -838,7 +838,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.22.7
       '@babel/types': 7.22.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -1626,7 +1626,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       espree: 9.6.1
       globals: 13.20.0
       ignore: 5.2.4
@@ -2039,7 +2039,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -2173,7 +2173,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@types/debug': 4.1.8
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       semver: 7.5.4
       superstruct: 1.0.3
     transitivePeerDependencies:
@@ -4327,14 +4327,8 @@ packages:
     resolution: {integrity: sha512-V0ozN02taiBaOOqTWTBwqt4l2WWd+3Ts8KFCAybDua/z8msGygV1Ktq+anR/nScZDuocjlcdrns4noCLGkT8yg==}
     dev: false
 
-  /@superfluid-finance/tokenlist@1.2.0:
-    resolution: {integrity: sha512-RL158g/Ejn0GTDcDWWwrXSn7aIlaLVVhDHaB2J6JqXxxJl+G+6yMIeHjnlT9q2veWWHa0o08qlf2LGfMnQG/bA==}
-    dependencies:
-      '@uniswap/token-lists': 1.0.0-beta.33
-    dev: false
-
-  /@superfluid-finance/tokenlist@1.3.0:
-    resolution: {integrity: sha512-eT0GCRici+KyDRGulvBsM5H/yc72bRM+FTpgAU5zK+vEh9Cq9lxMdOLjaCa+TsA3s3K+yf+8dWX9XFXOHTxc6w==}
+  /@superfluid-finance/tokenlist@1.3.1:
+    resolution: {integrity: sha512-3l15yGitKImgEf3zhl+AbPbrs8KPVfG6VROQoOKqXJkXJSGhFq3VQB4yWIFxmFUOwycb88/MFc50zGRgWtdHlA==}
     dependencies:
       '@uniswap/token-lists': 1.0.0-beta.33
     dev: false
@@ -4542,7 +4536,7 @@ packages:
       big.js: 6.2.1
       bn.js: 5.2.1
       cbor: 5.2.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       lodash: 4.17.21
       semver: 7.5.2
       utf8: 3.0.0
@@ -4562,7 +4556,7 @@ packages:
     resolution: {integrity: sha512-IwVQZG9RVNwTdn321+jbFIcky3/kZLkCtq8tqil4jZwivvmZQg8rIVC8GJ7Lkrmixl9/yTyQNL6GtIUUvkZxyA==}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4577,7 +4571,7 @@ packages:
       '@truffle/error': 0.1.1
       '@truffle/interface-adapter': 0.5.35
       bignumber.js: 7.2.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       ethers: 4.0.49
       web3: 1.7.4
       web3-core-helpers: 1.7.4
@@ -4601,7 +4595,7 @@ packages:
       '@truffle/error': 0.2.1
       '@truffle/interface-adapter': 0.5.35
       bignumber.js: 7.2.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       ethers: 4.0.49
       web3: 1.8.2
       web3-core-helpers: 1.8.2
@@ -4622,7 +4616,7 @@ packages:
       '@trufflesuite/chromafi': 3.0.0
       bn.js: 5.2.1
       chalk: 2.4.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       highlightjs-solidity: 2.0.6
     transitivePeerDependencies:
       - supports-color
@@ -5043,7 +5037,7 @@ packages:
       '@typescript-eslint/type-utils': 6.0.0(eslint@8.44.0)(typescript@5.1.6)
       '@typescript-eslint/utils': 6.0.0(eslint@8.44.0)(typescript@5.1.6)
       '@typescript-eslint/visitor-keys': 6.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 8.44.0
       grapheme-splitter: 1.0.4
       graphemer: 1.4.0
@@ -5070,7 +5064,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.6)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 8.44.0
       typescript: 5.1.6
     transitivePeerDependencies:
@@ -5090,7 +5084,7 @@ packages:
       '@typescript-eslint/types': 6.0.0
       '@typescript-eslint/typescript-estree': 6.0.0(typescript@5.1.6)
       '@typescript-eslint/visitor-keys': 6.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 8.44.0
       typescript: 5.1.6
     transitivePeerDependencies:
@@ -5124,7 +5118,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.0.0(typescript@5.1.6)
       '@typescript-eslint/utils': 6.0.0(eslint@8.44.0)(typescript@5.1.6)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 8.44.0
       ts-api-utils: 1.0.1(typescript@5.1.6)
       tsutils: 3.21.0(typescript@5.1.6)
@@ -5153,7 +5147,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
@@ -5173,7 +5167,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.0.0
       '@typescript-eslint/visitor-keys': 6.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
@@ -5893,7 +5887,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -5902,7 +5896,7 @@ packages:
     resolution: {integrity: sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==}
     engines: {node: '>= 8.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       depd: 2.0.0
       humanize-ms: 1.2.1
     transitivePeerDependencies:
@@ -6273,7 +6267,7 @@ packages:
   /axios@0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.2(debug@4.3.4)
+      follow-redirects: 1.15.2
     transitivePeerDependencies:
       - debug
     dev: false
@@ -7649,6 +7643,16 @@ packages:
     dependencies:
       ms: 2.0.0
 
+  /debug@3.2.7:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+
   /debug@3.2.7(supports-color@8.1.1):
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -7659,6 +7663,7 @@ packages:
     dependencies:
       ms: 2.1.3
       supports-color: 8.1.1
+    dev: true
 
   /debug@4.1.1:
     resolution: {integrity: sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==}
@@ -7672,6 +7677,17 @@ packages:
       ms: 2.1.3
     dev: true
 
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -7683,6 +7699,7 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 8.1.1
+    dev: true
 
   /decamelize-keys@1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
@@ -8631,7 +8648,7 @@ packages:
   /eslint-import-resolver-node@0.3.7:
     resolution: {integrity: sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==}
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       is-core-module: 2.12.1
       resolve: 1.22.2
     transitivePeerDependencies:
@@ -8644,7 +8661,7 @@ packages:
       eslint: '*'
       eslint-plugin-import: '*'
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.44.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.44.0)
@@ -8682,7 +8699,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.44.0)(typescript@5.1.6)
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       eslint: 8.44.0
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.44.0)
@@ -8703,7 +8720,7 @@ packages:
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       doctrine: 2.1.0
       eslint: 8.44.0
       eslint-import-resolver-node: 0.3.7
@@ -8854,7 +8871,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.1
@@ -9573,6 +9590,16 @@ packages:
   /flatted@3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
 
+  /follow-redirects@1.15.2:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: false
+
   /follow-redirects@1.15.2(debug@4.3.4):
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
     engines: {node: '>=4.0'}
@@ -9583,6 +9610,7 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
+    dev: true
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -10433,7 +10461,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -14625,6 +14653,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       has-flag: 4.0.0
+    dev: true
 
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^7.58.1
         version: 7.58.1(next@13.4.9)(react@18.2.0)
       '@superfluid-finance/tokenlist':
-        specifier: ^1.3.1
-        version: 1.3.1
+        specifier: ^1.3.2
+        version: 1.3.2
       '@superfluid-finance/widget':
         specifier: workspace:*
         version: link:../../packages/widget
@@ -169,8 +169,8 @@ importers:
         specifier: ^7.58.1
         version: 7.58.1(next@13.4.9)(react@18.2.0)
       '@superfluid-finance/tokenlist':
-        specifier: ^1.3.1
-        version: 1.3.1
+        specifier: ^1.3.2
+        version: 1.3.2
       '@superfluid-finance/widget':
         specifier: workspace:*
         version: link:../../packages/widget
@@ -239,8 +239,8 @@ importers:
         specifier: ^7.59.2
         version: 7.59.2(next@13.4.9)(react@18.2.0)
       '@superfluid-finance/tokenlist':
-        specifier: ^1.3.1
-        version: 1.3.1
+        specifier: ^1.3.2
+        version: 1.3.2
       '@superfluid-finance/widget':
         specifier: workspace:*
         version: link:../../packages/widget
@@ -290,8 +290,8 @@ importers:
         specifier: ^7.59.2
         version: 7.59.2(next@13.4.9)(react@18.2.0)
       '@superfluid-finance/tokenlist':
-        specifier: ^1.3.1
-        version: 1.3.1
+        specifier: ^1.3.2
+        version: 1.3.2
       '@superfluid-finance/widget':
         specifier: workspace:*
         version: link:../../packages/widget
@@ -341,8 +341,8 @@ importers:
         specifier: ^1.0.6
         version: 1.0.6(@types/react@18.2.15)(react-dom@18.2.0)(react@18.2.0)(viem@1.2.15)(wagmi@1.3.8)
       '@superfluid-finance/tokenlist':
-        specifier: ^1.3.1
-        version: 1.3.1
+        specifier: ^1.3.2
+        version: 1.3.2
       '@superfluid-finance/widget':
         specifier: workspace:*
         version: link:../../packages/widget
@@ -396,8 +396,8 @@ importers:
   examples/widget-vite-react-web3modal:
     dependencies:
       '@superfluid-finance/tokenlist':
-        specifier: ^1.3.1
-        version: 1.3.1
+        specifier: ^1.3.2
+        version: 1.3.2
       '@superfluid-finance/widget':
         specifier: workspace:*
         version: link:../../packages/widget
@@ -457,8 +457,8 @@ importers:
   examples/widget-webcomponent:
     dependencies:
       '@superfluid-finance/tokenlist':
-        specifier: ^1.3.1
-        version: 1.3.1
+        specifier: ^1.3.2
+        version: 1.3.2
       '@superfluid-finance/widget':
         specifier: workspace:*
         version: link:../../packages/widget
@@ -511,8 +511,8 @@ importers:
         specifier: ^1.1.8
         version: 1.1.8
       '@superfluid-finance/tokenlist':
-        specifier: ^1.3.1
-        version: 1.3.1
+        specifier: ^1.3.2
+        version: 1.3.2
       blockies-ts:
         specifier: ^1.0.0
         version: 1.0.0
@@ -4327,8 +4327,8 @@ packages:
     resolution: {integrity: sha512-V0ozN02taiBaOOqTWTBwqt4l2WWd+3Ts8KFCAybDua/z8msGygV1Ktq+anR/nScZDuocjlcdrns4noCLGkT8yg==}
     dev: false
 
-  /@superfluid-finance/tokenlist@1.3.1:
-    resolution: {integrity: sha512-3l15yGitKImgEf3zhl+AbPbrs8KPVfG6VROQoOKqXJkXJSGhFq3VQB4yWIFxmFUOwycb88/MFc50zGRgWtdHlA==}
+  /@superfluid-finance/tokenlist@1.3.2:
+    resolution: {integrity: sha512-vwP+oNpn82lnRFrpiSM8xDGVrSGaNFlfze2+s6rCsu9+8YhUhKbZL6jlWyIh0p250G5q2dWLI9HRnrDNg6gs0g==}
     dependencies:
       '@uniswap/token-lists': 1.0.0-beta.33
     dev: false


### PR DESCRIPTION
The **displaying** of the underlying token balance in the wrap view wasn't accounting for the decimals. This is a fix for that.

Note that the decimals were already handled for the allowance call.