### PR TITLE
Fix: less tokens being wrapped when underlying token has less than 18 decimals

### DIFF
--- a/.changeset/brown-dolphins-sneeze.md
+++ b/.changeset/brown-dolphins-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@superfluid-finance/widget": patch
+---
+
+Fix less tokens being wrapped into Super Tokens when underlying token's decimals are not 18

--- a/packages/widget/src/CommandMapper.tsx
+++ b/packages/widget/src/CommandMapper.tsx
@@ -164,12 +164,12 @@ export function WrapIntoSuperTokensCommandMapper({
           abi: nativeAssetSuperTokenABI,
           functionName: "upgradeByETH",
           address: cmd.superTokenAddress,
-          value: cmd.amountWei,
+          value: cmd.amountWeiFromUnderlyingTokenDecimals,
         }),
       );
     } else {
       if (allowance !== undefined) {
-        if (allowance < cmd.amountWei) {
+        if (allowance < cmd.amountWeiFromUnderlyingTokenDecimals) {
           contractWrites_.push(
             createContractWrite({
               commandId: cmd.id,
@@ -180,7 +180,10 @@ export function WrapIntoSuperTokensCommandMapper({
               abi: erc20ABI,
               functionName: "approve",
               address: cmd.underlyingToken.address,
-              args: [cmd.superTokenAddress, cmd.amountWei],
+              args: [
+                cmd.superTokenAddress,
+                cmd.amountWeiFromUnderlyingTokenDecimals,
+              ],
             }),
           );
         }
@@ -195,7 +198,7 @@ export function WrapIntoSuperTokensCommandMapper({
             abi: superTokenABI,
             address: cmd.superTokenAddress,
             functionName: "upgrade",
-            args: [cmd.amountWei],
+            args: [cmd.amountWeiFromSuperTokenDecimals],
           }),
         );
       }

--- a/packages/widget/src/commands.ts
+++ b/packages/widget/src/commands.ts
@@ -12,12 +12,16 @@ export type WrapIntoSuperTokensCommand = {
     | {
         isNativeAsset: false;
         address: Address;
+        decimals: number;
       }
     | {
         isNativeAsset: true;
         address: undefined;
+        decimals: number;
       };
-  amountWei: bigint;
+  amountInUnits: `${number}`;
+  amountWeiFromSuperTokenDecimals: bigint;
+  amountWeiFromUnderlyingTokenDecimals: bigint;
 };
 
 export type EnableAutoWrapCommand = {

--- a/packages/widget/src/formValuesToCommands.ts
+++ b/packages/widget/src/formValuesToCommands.ts
@@ -1,5 +1,5 @@
 import { nanoid } from "nanoid";
-import { Address, parseEther, parseUnits } from "viem";
+import { Address, formatUnits, parseEther, parseUnits } from "viem";
 
 import { Command } from "./commands.js";
 import { autoWrapStrategyAddress } from "./core/index.js";
@@ -33,11 +33,6 @@ export const formValuesToCommands = (
   // TODO(KK): Clean-up the bangs.
 
   if (isWrapperSuperToken) {
-    const wrapAmount = parseUnits(
-      wrapAmountInUnits ? wrapAmountInUnits : "0",
-      underlyingTokenInfo!.decimals,
-    );
-
     const underlyingToken = isWrapperSuperToken
       ? ({
           isNativeAsset: false,
@@ -50,7 +45,13 @@ export const formValuesToCommands = (
           decimals: underlyingTokenInfo!.decimals,
         } as const);
 
-    if (wrapAmount !== 0n) {
+    const amountWeiFromUnderlyingTokenDecimals = parseUnits(
+      wrapAmountInUnits,
+      underlyingToken.decimals,
+    );
+    const amountWeiFromSuperTokenDecimals = parseUnits(wrapAmountInUnits, 18); // Super Tokens always have 18 decimals.
+
+    if (amountWeiFromUnderlyingTokenDecimals !== 0n) {
       commands.push({
         id: nanoid(),
         type: "Wrap into Super Tokens",
@@ -58,7 +59,12 @@ export const formValuesToCommands = (
         superTokenAddress,
         accountAddress,
         underlyingToken,
-        amountWei: wrapAmount,
+        amountInUnits: formatUnits(
+          amountWeiFromUnderlyingTokenDecimals,
+          underlyingToken.decimals,
+        ) as `${number}`,
+        amountWeiFromUnderlyingTokenDecimals,
+        amountWeiFromSuperTokenDecimals,
       });
     }
 

--- a/packages/widget/src/previews/WrapIntoSuperTokensPreview.tsx
+++ b/packages/widget/src/previews/WrapIntoSuperTokensPreview.tsx
@@ -1,6 +1,4 @@
 import { Box, Paper, Stack, Typography } from "@mui/material";
-import { useMemo } from "react";
-import { formatUnits } from "viem";
 
 import { WrapIntoSuperTokensCommand } from "../commands.js";
 import { TokenAvatar } from "../TokenAvatar.js";
@@ -18,11 +16,6 @@ export function WrapIntoSuperTokensPreview({
   const underlyingToken = cmd.underlyingToken.isNativeAsset
     ? getNativeAsset(cmd.chainId)
     : getUnderlyingToken(cmd.underlyingToken.address);
-
-  const amountEther = useMemo(
-    () => formatUnits(cmd.amountWei, underlyingToken.decimals),
-    [cmd.amountWei],
-  );
 
   return (
     <Stack direction="column" alignItems="center" spacing={2.25}>
@@ -59,7 +52,7 @@ export function WrapIntoSuperTokensPreview({
             variant="body1"
             sx={{ mt: 0.5 }}
           >
-            {amountEther}
+            {cmd.amountInUnits}
           </Typography>
           <Typography
             data-testid="review-underlying-token-symbol"
@@ -86,7 +79,7 @@ export function WrapIntoSuperTokensPreview({
             variant="body1"
             sx={{ mt: 0.5 }}
           >
-            {amountEther}
+            {cmd.amountInUnits}
           </Typography>
           <Typography data-testid="review-super-token-symbol" variant="caption">
             {superToken.symbol}

--- a/packages/widget/src/useCommandValidationSchema.ts
+++ b/packages/widget/src/useCommandValidationSchema.ts
@@ -32,7 +32,7 @@ export const useCommandValidationSchema = () =>
                     ? undefined
                     : cmd.underlyingToken.address,
                 });
-                return cmd.amountWei <= balance;
+                return cmd.amountWeiFromUnderlyingTokenDecimals <= balance;
               },
               {
                 message:
@@ -119,7 +119,9 @@ export const useCommandValidationSchema = () =>
 
             const neededDeposit = newDeposit - existingDeposit;
             const availableBalanceWithWrapAmount =
-              availableBalance + (wrapIntoSuperTokensCommand?.amountWei ?? 0n);
+              availableBalance +
+              (wrapIntoSuperTokensCommand?.amountWeiFromUnderlyingTokenDecimals ??
+                0n);
 
             return availableBalanceWithWrapAmount >= neededDeposit;
           },
@@ -158,7 +160,9 @@ export const useCommandValidationSchema = () =>
               mapTimePeriodToSeconds(cmd.flowRate.period);
 
             const availableBalanceWithWrapAmount =
-              availableBalance + (wrapIntoSuperTokensCommand?.amountWei ?? 0n);
+              availableBalance +
+              (wrapIntoSuperTokensCommand?.amountWeiFromUnderlyingTokenDecimals ??
+                0n);
             const accountFlowRateWithNewFlowRate =
               accountFlowRate - flowRateWeiPerSecond;
 


### PR DESCRIPTION
Less token were being wrapped when underlying token had less than 18 decimals. Approve allowance was OK.

Quick summary:
* `approve` need to be called with underlying token decimals
* `upgrade` needs to be called with Super Token decimals
* `upgradeByEth` needs to be called with underlying token (the native asset) decimals

The mistake was calling `upgrade` with underlying token decimals.

We're lacking easily available testnet tokens for testing this scenario.