### PR TITLE
chore: separate widget props schema and clean-up typedoc

### DIFF
--- a/packages/widget/src/CheckoutConfig.ts
+++ b/packages/widget/src/CheckoutConfig.ts
@@ -1,13 +1,58 @@
+import { ThemeOptions } from "@mui/material";
 import { SuperTokenList } from "@superfluid-finance/tokenlist";
 import { z } from "zod";
 
-import { paymentDetailsSchema, productDetailsSchema } from "./core/index.js";
+import {
+  PaymentDetails,
+  paymentDetailsSchema,
+  ProductDetails,
+  productDetailsSchema,
+} from "./core/index.js";
+import { EventListeners } from "./EventListeners.js";
+import { WalletManager } from "./WalletManager.js";
 
-export const checoutConfigSchema = z.object({
-  productDetails: productDetailsSchema,
-  paymentDetails: paymentDetailsSchema,
+export const checkoutConfigSchema = z.object({
+  /**
+   * @inheritdoc ProductDetails
+   */
+  productDetails: productDetailsSchema.transform((x) => x as ProductDetails),
+  /**
+   * @inheritdoc PaymentDetails
+   */
+  paymentDetails: paymentDetailsSchema.transform((x) => x as PaymentDetails),
+  /**
+   * The token list that contains Super Tokens and their underlying tokens.
+   */
+  tokenList: z.custom<SuperTokenList>(),
 });
 
-export type CheckoutConfig = z.infer<typeof checoutConfigSchema> & {
-  readonly tokenList: SuperTokenList; // TODO: move to zod schema
-};
+export interface CheckoutConfig extends z.infer<typeof checkoutConfigSchema> {}
+
+const widgetPropsSchema = checkoutConfigSchema.merge(
+  z.object({
+    /**
+     * The MUI theme object to style the widget. Learn more about it from the MUI documentation: https://mui.com/material-ui/customization/default-theme/
+     */
+    theme: z
+      .custom<Omit<ThemeOptions, "unstable_strictMode" | "unstable_sxConfig">>()
+      .optional(),
+    /**
+     * Whether the stepper UI component inside the widget is vertical or horizontal. Vertical is better supported.
+     */
+    stepper: z
+      .custom<{
+        orientation: "vertical" | "horizontal";
+      }>()
+      .optional(),
+    /**
+     * @inheritdoc WalletManager
+     */
+    walletManager: z.custom<WalletManager>(),
+    /**
+     * @inheritdoc EventListeners
+     */
+    eventListeners: z.custom<EventListeners>().optional(),
+  }),
+);
+
+export interface WidgetProps extends z.infer<typeof widgetPropsSchema> {}

--- a/packages/widget/src/WalletManager.ts
+++ b/packages/widget/src/WalletManager.ts
@@ -1,5 +1,33 @@
 /**
  * An interface for interacting with a wallet management library (e.g. Web3Modal, RainbowKit, ConnectKit etc).
+ *
+ * @example
+ * Example with React & RainbowKit.
+ *
+ * ```typescript
+ * const { openConnectModal, connectModalOpen } = useConnectModal();
+ * const walletManager = useMemo(
+ *   () => ({
+ *     open: async () => openConnectModal?.(),
+ *     isOpen: connectModalOpen,
+ *   }),
+ *   [openConnectModal, connectModalOpen]
+ * );
+ * ```
+ *
+ * @example
+ * Example with React & Web3Modal.
+ *
+ * ```typescript
+ * const { open, isOpen } = useWeb3Modal();
+ * const walletManager = useMemo(
+ *   () => ({
+ *     open,
+ *     isOpen,
+ *   }),
+ *   [open, isOpen],
+ * );
+ * ```
  */
 export interface WalletManager {
   /**

--- a/packages/widget/src/Widget.tsx
+++ b/packages/widget/src/Widget.tsx
@@ -2,7 +2,6 @@ import {
   Alert,
   AlertTitle,
   createTheme,
-  ThemeOptions,
   ThemeProvider,
 } from "@mui/material";
 import { deepmerge } from "@mui/utils";
@@ -13,27 +12,18 @@ import { useCallback, useMemo } from "react";
 import { Address, zeroAddress } from "viem";
 import { fromZodError } from "zod-validation-error";
 
-import { CheckoutConfig, checoutConfigSchema } from "./CheckoutConfig.js";
+import {
+  checkoutConfigSchema,
+  WidgetProps,
+} from "./CheckoutConfig.js";
 import { ChainId, SupportedNetwork, supportedNetworks } from "./core/index.js";
-import { EventListeners } from "./EventListeners.js";
 import { PaymentOptionWithTokenInfo } from "./formValues.js";
 import { addSuperTokenInfoToPaymentOptions } from "./helpers/addSuperTokenInfoToPaymentOptions.js";
 import { filterSuperTokensFromTokenList } from "./helpers/filterSuperTokensFromTokenList.js";
 import { mapSupportedNetworksFromPaymentOptions } from "./helpers/mapSupportedNetworksFromPaymentOptions.js";
 import { buildThemeOptions } from "./theme.js";
-import { WalletManager } from "./WalletManager.js";
 import { WidgetContext, WidgetContextValue } from "./WidgetContext.js";
 import { ViewProps, WidgetView } from "./WidgetView.js";
-
-export type WidgetProps = ViewProps &
-  CheckoutConfig & {
-    eventListeners?: EventListeners;
-    walletManager: WalletManager;
-    theme?: Omit<ThemeOptions, "unstable_strictMode" | "unstable_sxConfig">;
-    stepper?: {
-      orientation: "vertical" | "horizontal";
-    };
-  };
 
 /**
  * The entrypoint to the Superfluid widget.
@@ -47,7 +37,7 @@ export function Widget({
   stepper: stepper_ = { orientation: "vertical" },
   eventListeners,
   ...viewProps
-}: WidgetProps) {
+}: WidgetProps & ViewProps) {
   const { paymentOptions } = paymentDetails;
 
   const { superTokens, underlyingTokens } = useMemo(
@@ -185,7 +175,7 @@ export function Widget({
     return createTheme(themeOptions);
   }, [theme_]);
 
-  const validationResult = checoutConfigSchema.safeParse({
+  const validationResult = checkoutConfigSchema.safeParse({
     productDetails,
     paymentDetails,
   });

--- a/packages/widget/src/core/PaymentDetails.ts
+++ b/packages/widget/src/core/PaymentDetails.ts
@@ -6,4 +6,7 @@ export const paymentDetailsSchema = z.object({
   paymentOptions: z.array(paymentOptionSchema).min(1),
 });
 
-export type PaymentDetails = z.infer<typeof paymentDetailsSchema>;
+/**
+ * The details of the payment options for the checkout flow.
+ */
+export interface PaymentDetails extends z.infer<typeof paymentDetailsSchema> {}

--- a/packages/widget/src/core/PaymentOption.ts
+++ b/packages/widget/src/core/PaymentOption.ts
@@ -48,5 +48,9 @@ export const paymentOptionSchema = z.object({
     .optional(),
 });
 
-export type PaymentOption = z.infer<typeof paymentOptionSchema>;
+/**
+ * The details of a single payment option for the checkout flow.
+ */
+export interface PaymentOption extends z.infer<typeof paymentOptionSchema> {}
+
 export type FlowRate = z.infer<typeof flowRateSchema>;

--- a/packages/widget/src/core/ProductDetails.ts
+++ b/packages/widget/src/core/ProductDetails.ts
@@ -1,13 +1,31 @@
 import { z } from "zod";
 
 export const productDetailsSchema = z.object({
+  /**
+   * The name of the checkout product.
+   */
   name: z.string(),
+  /**
+   * The description of the checkout product.
+   */
   description: z.string().optional(),
+  /**
+   * The image URI of the checkout product. Can be an URL, can be a data URI (e.g. inline Base64).
+   */
   imageURI: z.string().optional(),
   // # Success Button
+  /**
+   * Text shows on the success button in the final screen of the checkout.
+   */
   successText: z.string().optional(),
+  /**
+   * The URL to redirect to when the success button is clicked.
+   */
   successURL: z.string().optional(),
   // TODO(KK): Move success button related things to a separate object.
 });
 
-export type ProductDetails = z.infer<typeof productDetailsSchema>;
+/**
+ * The details of the checkout product.
+ */
+export interface ProductDetails extends z.infer<typeof productDetailsSchema> {}

--- a/packages/widget/src/formValues.ts
+++ b/packages/widget/src/formValues.ts
@@ -17,9 +17,8 @@ const paymentOptionWithTokenInfoSchema = z.object({
   underlyingToken: z.custom<TokenInfo>().nullable(),
 });
 
-export type PaymentOptionWithTokenInfo = z.infer<
-  typeof paymentOptionWithTokenInfoSchema
->;
+export interface PaymentOptionWithTokenInfo
+  extends z.infer<typeof paymentOptionWithTokenInfoSchema> {}
 
 export const checkoutFormSchema = z.object({
   accountAddress: addressSchema,

--- a/packages/widget/src/index.ts
+++ b/packages/widget/src/index.ts
@@ -4,17 +4,24 @@ import { Widget } from "./Widget.js";
 
 export type { WidgetProps } from "./CheckoutConfig";
 export type {
+  ChainId,
+  FlowRate,
   PaymentDetails,
   PaymentOption,
   ProductDetails,
+  TimePeriod,
 } from "./core/index.js";
 export {
+  cfAv1ForwarderABI, // TODO: Export ABI from @superfluid-finance/widget/abi"
   supportedNetwork,
   supportedNetworks,
   timePeriods,
 } from "./core/index.js";
 export type { EventListeners } from "./EventListeners";
 export type { WalletManager } from "./WalletManager";
-export * from "@superfluid-finance/tokenlist";
+export * from "@superfluid-finance/tokenlist"; // TODO: Export from @superfluid-finance/widget/tokenlist
+
+// TODO: Export Zod schemas from @superfluid-finance/widget/zod
+export { paymentDetailsSchema,productDetailsSchema } from "./core/index.js";
 
 export default Widget;

--- a/packages/widget/src/index.ts
+++ b/packages/widget/src/index.ts
@@ -2,15 +2,19 @@
 
 import { Widget } from "./Widget.js";
 
+export type { WidgetProps } from "./CheckoutConfig";
+export type {
+  PaymentDetails,
+  PaymentOption,
+  ProductDetails,
+} from "./core/index.js";
 export {
   supportedNetwork,
   supportedNetworks,
   timePeriods,
 } from "./core/index.js";
-export * from "./core/index.js";
 export type { EventListeners } from "./EventListeners";
 export type { WalletManager } from "./WalletManager";
-export type { WidgetProps } from "./Widget";
 export * from "@superfluid-finance/tokenlist";
 
 export default Widget;


### PR DESCRIPTION
Cleaning up the types and comments in the widget to make the reference docs more usable. Work in progress in grand scheme of things -- this is just to get the ball rolling.

Should be non-breaking but I removed some exports which could be breaking.

View the reference docs here: https://widget-reference-docs-git-clean-up-ty-ae1392-superfluid-finance.vercel.app/