### PR TITLE
fix: make check for upfront transfers non-blocking

### DIFF
--- a/.changeset/afraid-fans-tease.md
+++ b/.changeset/afraid-fans-tease.md
@@ -1,0 +1,5 @@
+---
+"@superfluid-finance/widget": patch
+---
+
+Make the check for existing upfront transfers lighter and non-blocking


### PR DESCRIPTION
Doesn't make sense to block moving forward with this secondary query failing.