### PR TITLE
Docs Fixes

### DIFF
--- a/docs/pages/_meta.json
+++ b/docs/pages/_meta.json
@@ -19,7 +19,6 @@
     "newWindow": true
   },
   "index": {
-    "title": "Home",
-    "children": []
+    "title": "Home"
   }
 }

--- a/docs/pages/docs/integrate-the-widget/how-to-integrate.mdx
+++ b/docs/pages/docs/integrate-the-widget/how-to-integrate.mdx
@@ -26,6 +26,8 @@ Craft your Widget JSON following our step-by-step guide [here](../building-the-w
 
 ### Step 4: Implement the Widget in Your Component
 
+In this example, we name our JSON file `data`:
+
 ```jsx
 export function MyComponent() {
   return (

--- a/docs/pages/docs/quickstart.mdx
+++ b/docs/pages/docs/quickstart.mdx
@@ -9,10 +9,8 @@ Welcome to the quickstart guide for the Superfluid Subscription Widget. Follow t
 
 - [Prerequisites](#prerequisites)
 - [Step 1: Building Your Widget](#step-1-building-your-widget)
-- [Step 2: Integrating Widget into Your Website](#step-2-integrating-widget-into-your-website)
+- [Step 2: Integrating Widget into Your Website](#step-2-integrating-widget-into-your-app)
 - [Step 3: Verifying Active Streams](#step-3-verifying-active-streams)
-- [Troubleshooting](#troubleshooting)
-- [Further Reading](#further-reading)
 
 ## Prerequisites
 
@@ -110,7 +108,7 @@ If you want a more integrated experience where the Superfluid widget resides wit
    npm install @superfluid-finance/widget
    ```
 
-2. **Integrate in Your App**: Now, you can import the widget into your application. We won't dive deep into the details here, but you can refer to the detailed [Superfluid Widget Integration Guide](./integration/how-to-integrate).
+2. **Integrate in Your App**: Now, you can import the widget into your application. We won't dive deep into the details here, but you can refer to the detailed [Superfluid Widget Integration Guide](./integrate-the-widget/how-to-integrate.mdx).
 
 ## Step 3: Verifying Active Streams
 


### PR DESCRIPTION
Broken link on Quickstart @ Step 2
Added context for `data`in the integrate widget section
Fixed _meta.json children