### PR TITLE
Adding guide about custom token lists to docs

### DIFF
--- a/docs/pages/docs/building-the-widget.mdx
+++ b/docs/pages/docs/building-the-widget.mdx
@@ -10,7 +10,7 @@ In order to build your widget and integrate it inside your app, you need to have
 ## Table of Contents
 
 - [Building your Widget using JSON](#using-a-json-configuration)
-- [Building your Widget using the UI](#uusing-the-user-interface-widget-builder)
+- [Building your Widget using the UI](#using-the-user-interface-widget-builder)
 
 ## Using a JSON Configuration
 
@@ -92,6 +92,8 @@ The `type` field denotes the widget's visual style:
   "type": "page"
 }
 ```
+
+
 
 ## Using the User Interface (Widget Builder)
 

--- a/docs/pages/docs/integrate-the-widget/_meta.json
+++ b/docs/pages/docs/integrate-the-widget/_meta.json
@@ -1,5 +1,6 @@
 {
   "how-to-integrate": "How to Integrate",
+  "create-your-custom-token-list": "Create your Token List",
   "getting-stream-data": "Getting Stream Data",
   "handling-events": "Handling Events"
 }

--- a/docs/pages/docs/integrate-the-widget/create-your-custom-token-list.mdx
+++ b/docs/pages/docs/integrate-the-widget/create-your-custom-token-list.mdx
@@ -1,0 +1,45 @@
+# Create your Custom Token list
+As you saw in the [Integration Section](/docs/integrate-the-widget/how-to-integrate.mdx), you can use Superfluid's Token List package to get the list of tokens supported by Superfluid.
+However, you can also create your own token list and inject it into the widget.
+This is useful if you want to create a custom token list for your own application.
+Your token list should be a JSON file following a structure like so:
+
+```json
+{
+  "name": "Superfluid Token List",
+  "version": {
+    "major": 2,
+    "minor": 3,
+    "patch": 0
+  },
+  "timestamp": "2023-10-20T08:18:44.184Z",
+  "tokens": [
+    {
+      "address": "0x288398f314d472b82c44855f3f6ff20b633c2a97",
+      "name": "Super USD Coin",
+      "symbol": "USDCx",
+      "decimals": 18,
+      "chainId": 43114,
+      "extensions": {
+        "superTokenInfo": {
+          "type": "Wrapper",
+          "underlyingTokenAddress": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e"
+        }
+      },
+      "logoURI": "https://raw.githubusercontent.com/superfluid-finance/assets/master/public/tokens/usdc/icon.svg",
+      "tags": ["supertoken", "tier_a"]
+    },
+    {
+      "address": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+      "name": "USD Coin",
+      "symbol": "USDC",
+      "decimals": 6,
+      "chainId": 43114,
+      "logoURI": "https://raw.githubusercontent.com/superfluid-finance/assets/master/public/tokens/usdc/icon.svg",
+      "tags": ["underlying"]
+    },
+// The rest of the token list
+}
+```
+
+The `tokens` array should contain all the tokens you want to support in your application.

--- a/docs/pages/docs/integrate-the-widget/create-your-custom-token-list.mdx
+++ b/docs/pages/docs/integrate-the-widget/create-your-custom-token-list.mdx
@@ -1,3 +1,5 @@
+import { Callout} from "nextra/components";
+
 # Create your Custom Token list
 As you saw in the [Integration Section](/docs/integrate-the-widget/how-to-integrate.mdx), you can use Superfluid's Token List package to get the list of tokens supported by Superfluid.
 However, you can also create your own token list and inject it into the widget.
@@ -42,4 +44,9 @@ Your token list should be a JSON file following a structure like so:
 }
 ```
 
-The `tokens` array should contain all the tokens you want to support in your application.
+<Callout type="info">
+
+The `tokens` array should contain all the tokens you want to support in your application. Once your token list is ready, you can inject it into the widget by passing it as a prop `tokenList` to the `SuperfluidWidget` component.
+For further instructions, check [Integration Section](/docs/integrate-the-widget/how-to-integrate.mdx).
+
+</Callout>

--- a/docs/pages/docs/integrate-the-widget/how-to-integrate.mdx
+++ b/docs/pages/docs/integrate-the-widget/how-to-integrate.mdx
@@ -41,3 +41,10 @@ export function MyComponent() {
 ```
 
 </Steps> 
+
+<Callout type="default">
+
+_You can create your own **custom Token List** if you the Super Tokens you want to use are not listed in the Superfluid Token List package.
+Learn more about how to do that in the [next section](/docs/integrate-the-widget/create-your-custom-token-list.mdx)._
+
+</Callout>


### PR DESCRIPTION
Quick change to the widget docs: Adding guide about custom token lists to docs